### PR TITLE
Fix negation features

### DIFF
--- a/base.py
+++ b/base.py
@@ -1503,7 +1503,8 @@ class IsNotNull(SQLComparison):
     
     def placeholder_pair(self):
         return "IS NOT NULL", []
-    def __neg(self):
+
+    def __neg__(self):
         return IsNull()
 
 
@@ -1518,7 +1519,7 @@ negation_dict_ = {
     In: NotIn,
 }
 negation_dict = Twd()
-negation_dict.update(negation_dict)
+negation_dict.update(negation_dict_)
 
 
 def get_comparison(statement: str, value1: SQLInput = None, value2: SQLInput = None) -> SQLComparison:


### PR DESCRIPTION
## Summary
- fix `IsNotNull.__neg__` typo
- populate `negation_dict` correctly

## Testing
- `python -m py_compile base.py parsers/*.py utils.py validators.py functions.py dsl.py exceptions.py`
- `python - <<'EOF'
import ExpressQL.base as base
from ExpressQL.base import SQLExpression, EqualTo, IsNotNull
print('negation_dict items after fix:', list(base.negation_dict.items()))
print('negation of EqualTo ->', -EqualTo(SQLExpression('age', 'column')))
print('negation of IsNotNull ->', -IsNotNull())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6845ececa46083268e3d8abf8309e862